### PR TITLE
Add support for Sony device name fields and LUT fields

### DIFF
--- a/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
+++ b/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
@@ -109,6 +109,16 @@ win = disp:AddWindow({
             ui:CheckBox{ID = "CheckComments", Text = "Comments", Checked = false,},
             ui:ComboBox{ID = "ComboComments", Enabled = false},
           },
+          ui:HGroup{
+            Weight = 0.1,
+            ui:CheckBox{ID = "CheckColorSpaceNotes", Text = "Color Space Notes", Checked = false,},
+            ui:ComboBox{ID = "ComboColorSpaceNotes", Enabled = false},
+          },
+          ui:HGroup{
+            Weight = 0.1,
+            ui:CheckBox{ID = "CheckLUTUsed", Text = "LUT Used", Checked = false,},
+            ui:ComboBox{ID = "ComboLUTUsed", Enabled = false},
+          },
 
         },
         
@@ -207,6 +217,8 @@ exifBoxes = {
   { exif = 'FirmwareVersion', check = itm.CheckCameraFirmware, combo = itm.ComboCameraFirmware},
   { exif = 'GPSCoordinates', check = itm.CheckLocation, combo = itm.ComboLocation},
   { exif = 'Comment', check = itm.CheckComments, combo = itm.ComboComments},
+  { exif = 'AcquisitionRecordGroupItemValue', check = itm.CheckColorSpaceNotes, combo = itm.ComboColorSpaceNotes},
+  { exif = 'RelevantFilesRelatedToFile', check = itm.CheckLUTUsed, combo = itm.ComboLUTUsed},
 }
 
   -- exiftool recognized attributes
@@ -252,6 +264,8 @@ exifAttributes = {
   'VideoFrameRate',
   'WhiteBalance',
   'WhiteBalanceFineTune',
+  'AcquisitionRecordGroupItemValue',
+  'RelevantFilesRelatedToFile',
 }
 
 

--- a/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
+++ b/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
@@ -223,6 +223,7 @@ exifBoxes = {
 
   -- exiftool recognized attributes
 exifAttributes = {
+  'AcquisitionRecordGroupItemValue',
   'Aperture',
   'AudioChannels',
   'AudioSampleRate',
@@ -256,6 +257,7 @@ exifAttributes = {
   'Megapixels',
   'Model',
   'ModifyDate',
+  'RelevantFilesRelatedToFile',
   'Rotation',
   'Saturation',
   'Sharpness',
@@ -266,8 +268,6 @@ exifAttributes = {
   'VideoFrameRate',
   'WhiteBalance',
   'WhiteBalanceFineTune',
-  'AcquisitionRecordGroupItemValue',
-  'RelevantFilesRelatedToFile',
 }
 
 

--- a/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
+++ b/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
@@ -237,6 +237,8 @@ exifAttributes = {
   'CropHiSpeed',
   'DateTimeOriginal',
   'DaylightSavings',
+  'DeviceManufacturer',
+  'DeviceModelName',
   'FieldOfView',
   'FileName',
   'FilterEffect',


### PR DESCRIPTION
* Allows the Color Primaries & Gamma set in a Sony camera to be viewed inside Resolve's "Color Space Notes" field.
* Allows `DeviceManufacturer` and `DeviceModelName` from Sony cameras to be selected for those respective Resolve fields.

### Background

Sony seems to use just one line to indicate both the gamma (`s-log3`) and the colour primaries (`-cine` meaning SGamut3.Cine).

An example of the exiftool output on a Sony FX3 file:
```
~ exiftool -s /path/to/M4ROOT/CLIP/20240218_A_FX3_C0001.MP4 | sort
AcquisitionRecordChangeTableEventFrameCount: 0
AcquisitionRecordChangeTableEventStatus: start
AcquisitionRecordChangeTableName: ImagerControlInformation
AcquisitionRecordGroupItemName  : CaptureGammaEquation
AcquisitionRecordGroupItemValue : s-log3-cine
AcquisitionRecordGroupName      : CameraUnitMetadataSet
...
DeviceManufacturer              : Sony
DeviceModelName                 : ILME-FX3
...
ExifToolVersion                 : 12.60
...
RelevantFilesRelatedToFile      : rh_v1_neutral_+0.cube
RelevantFilesRelatedToRel       : LUT
```