### PR TITLE
UI improvements

### DIFF
--- a/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
+++ b/com.deric.ExifMetadata/Scripts/Comp/EXIF-metadata.lua
@@ -116,23 +116,6 @@ win = disp:AddWindow({
 
         ui:HGroup{
           Weight = 0.1,
-          ui:Label{
-            ID = "LabelSettings", Text = "Scan Settings",
-            Alignment = { AlignHCenter = true, AlignVCenter = true },
-          },
-        },
-        ui:VGap(5, 0.01),
-
-        ui:HGroup{
-          Weight = 0.1,
-          ui:CheckBox{ID = "CheckExtractEmbedded", Text = "Extract Embedded Data", Checked = true, ToolTip = 'Disabling this will speedup scanning for files with GPS or motion data, but might skip metadata on certain cameras'},
-          ui:CheckBox{ID = "CheckCurrentFolder", Text = "Scan Current Folder Only", Checked = false, ToolTip = 'Only scan the files in the folder currently selected or open in the media pool'},
-        },
-
-        ui:VGap(5, 0.01),
-
-        ui:HGroup{
-          Weight = 0.1,
           ui:VGroup{
             Weight = 0.1,
             ui:Button{ID = "BtnSelectAll", Text = "Select All",},
@@ -143,16 +126,33 @@ win = disp:AddWindow({
           }
         },
 
+      	ui:VGap(5, 0.01),
+
+        ui:HGroup{
+          Weight = 0.1,
+          ui:Label{
+            ID = "LabelSettings", Text = "Scan Settings",
+            Alignment = { AlignHCenter = true, AlignVCenter = true },
+          },
+        },
+        ui:VGap(5, 0.01),
+
+        ui:HGroup{
+          Weight = 0.1,
+          ui:CheckBox{ID = "CheckExtractEmbedded", Text = "Extract Embedded Data", Checked = true, ToolTip = 'Disabling this will speedup scanning for files with GPS or motion data, but might skip metadata on certain cameras'},
+          ui:CheckBox{ID = "CheckCurrentFolder", Text = "Scan Current Media Pool Folder Only", Checked = false, ToolTip = 'Only scan the files in the folder currently selected or open in the media pool'},
+        },
+
         ui:VGap(5, 0.01),
         ui:HGroup{
             Weight = 0.1,
             ui:VGroup{
               Weight = 0.1,
-              ui:Button{ID = "DryRun", Text = "Dry run", ToolTip = 'Scan the files without syncing the metadata with Resolve'},
+              ui:Button{ID = "DryRun", Text = "Preview Scan", ToolTip = 'Scan the files without modifying any clip metadata in Resolve yet'},
             },
             ui:VGroup{
               Weight = 0.1,
-              ui:Button{ID = "LoadMetadata", Text = "Sync MediaStore", ToolTip = 'Scan and sync the metadata with Resolve'},
+              ui:Button{ID = "LoadMetadata", Text = "Scan And Apply", ToolTip = 'Scan and apply the EXIF metadata to the media pool clips in Resolve'},
             }
         },
         ui:HGroup{


### PR DESCRIPTION
* Changed "Sync MediaStore" to "Scan and Apply".
  * Sync Mediastore was a bit vague to me the first time and I understand it may reference something internally. This new wording tells the user more precisely what will happen, first metadata will be scanned and then the new values applied to the Media Pool clips. Also another reason to avoid use of the word 'Sync', is that there is so two way syncing ocurring, just one way from EXIF from disk file to Media Pool items.
* Changed "Dry Run" to "Preview Scan". I get dry run from rsync but this is more understandable. 
* Moved the buttons for 'Select/Unselect All' to directly underneath the EXIF combos, since this is what they are controlling. This helps avoid confusion if Select all perhaps was thought to relate to Media Pool items, which the reset of the UI panel refers to.

Also thank you deric for this fantastic script. It has been working really well on a current project.